### PR TITLE
Don't checkout wp-tests on host

### DIFF
--- a/.env
+++ b/.env
@@ -4,5 +4,5 @@ DB_PASS=wordpress
 DB_NAME=wordpress
 DB_NAME_TESTS=test
 WP_DIR=/app/wp
-WP_TESTS_DIR=/app/wp-tests
+WP_TESTS_DIR=/tmp/wp-tests
 WP_CLI_CONFIG_PATH=/app/configs/wp-cli.yml

--- a/bin/lando/setup.sh
+++ b/bin/lando/setup.sh
@@ -84,8 +84,21 @@ wp core install \
 	--skip-email
 
 # Setup phpunit
-echo_heading "Setting up phpunit"
-ln -sf $LANDO_MOUNT/configs/wp-tests-config.php $WP_TESTS_DIR/wp-tests-config.php
+echo_heading "Setting up wp-tests"
+if [ ! -d "$WP_TESTS_PATH" ]; then
+	echo "Cloning WP Unit Tests => $WP_TESTS_PATH"
+	svn co --quiet https://develop.svn.wordpress.org/tags/$WP_VERSION/tests/phpunit/includes/ $WP_TESTS_PATH/includes
+	svn co --quiet https://develop.svn.wordpress.org/tags/$WP_VERSION/tests/phpunit/data/ $WP_TESTS_PATH/data
+else
+	echo "wp-tests already exists; skipping"
+fi
+
+if [ ! -f "$WP_TESTS_DIR/wp-tests-config.php" ]; then
+	echo "Mapping wp-tests config file"
+	ln -sf $LANDO_MOUNT/configs/wp-tests-config.php $WP_TESTS_DIR/wp-tests-config.php
+else
+	echo "wp-tests config file already exists; skipping"
+fi
 
 # Setup Search
 echo_heading "Setting up VIP Search"

--- a/vip-init.sh
+++ b/vip-init.sh
@@ -40,20 +40,6 @@ fi
 
 # ---
 
-echo_heading "WP Unit Tests"
-
-WP_TESTS_PATH="$ROOT_PATH/wp-tests"
-cd $ROOT_PATH
-if [ ! -d "$WP_TESTS_PATH" ]; then
-	echo "Cloning WP Unit Tests => $WP_TESTS_PATH"
-	svn co --quiet https://develop.svn.wordpress.org/tags/$WP_VERSION/tests/phpunit/includes/ $WP_TESTS_PATH/includes
-	svn co --quiet https://develop.svn.wordpress.org/tags/$WP_VERSION/tests/phpunit/data/ $WP_TESTS_PATH/data
-else
-	echo "WP Unit Test already exists; skipping"
-fi
-
-# ---
-
 echo_heading "Starting Lando"
 
 cd $ROOT_PATH


### PR DESCRIPTION
More files in the volume means more :(

We don't need really need to edit the wp-tests files typically anyway so mounting them from host => container is pointless. Instead, just make them available on the container under /tmp.