### PR TITLE
Set ElasticSearch version to 7 rather than 7.3

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -28,7 +28,7 @@ services:
     composer:
       phpunit/phpunit: '^6'
   vip-search:
-    type: elasticsearch:7.3
+    type: elasticsearch:7
   phpmyadmin:
     type: phpmyadmin
     hosts:


### PR DESCRIPTION
## Description

7 is the latest and greatest ElasticSearch. It's like 7.6 or something. 

The reason for this change is that 7.3 doesn't exist as a container despite being in the supported list. The only one from the supported list that has a container is 7. 

Going to have to watch and hope Lando update their ES offering or we'll have to go with a custom configuration that aims at the version we're using in production if disparities come up. Or we can do that beforehand if we want to be more responsible.