### PR TITLE
Use ES 7.5

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -35,7 +35,7 @@ services:
     composer:
       phpunit/phpunit: '^6'
   vip-search:
-    type: elasticsearch:7.5
+    type: elasticsearch:7.5.1
   phpmyadmin:
     type: phpmyadmin
     hosts:


### PR DESCRIPTION
In prod we (currently) use ES 7.5 so should match that in dev (the `7` tag wants to install `7.6.1`)