### PR TITLE
provide svn installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A development environment for [mu-plugins on VIP Go](https://github.com/Automatt
 ## Install
 
 1. Clone repo.
-1. Install SVN: `brew install svn`
+1. Install SVN: `brew install svn` (or use package manager of your choice).
 1. Install [Lando](https://docs.lando.dev/basics/installation.html).
 1. Install node+npm.
 1. Install Composer.


### PR DESCRIPTION
SVN is no longer provided by XCode.  Added instructions on how to install it.

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.5)_