### PR TITLE
Use Elasticsearch 7.8.0

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -37,7 +37,9 @@ services:
     composer:
       phpunit/phpunit: '^6'
   vip-search:
-    type: elasticsearch:7.5.1
+    type: elasticsearch:custom
+    overrides:
+      image: bitnami/elasticsearch:7.8.0
   phpmyadmin:
     type: phpmyadmin
     hosts:


### PR DESCRIPTION
## Description

We're upgrading to Elasticsearch 7.8, so let's test it.

## Setup

1. `lando destroy -y`
2. `./vip-init.sh`
3. `lando add-fake-data`
4. `lando wp vip-search index --setup`