### PR TITLE
Lando multisite support

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -16,6 +16,7 @@ config:
 proxy:
   appserver_nginx:
     - vip-go-dev.lndo.site
+    - '*.vip-go-dev.lndo.site'
 services:
   appserver:
     overrides:
@@ -58,6 +59,7 @@ tooling:
     description: "Run all tests: lando test"
     cmd:
       - cd /app/wp/wp-content/mu-plugins && phpunit
+
   add-fake-data:
     service: appserver
     description: "Add fake data described in '/configs/fixtures/test_fixtures.yml'. You can also use 'wp fixtures' directly to aim it at other files within lando."
@@ -75,3 +77,15 @@ tooling:
     description: "Swap your wp-content with a client repo or the vip-go-skeleton"
     cmd:
      - bash /app/bin/lando/vip-switch.sh
+
+  setup-multisite:
+    service: appserver
+    description: "Setup WordPress network to enable multisite mode"
+    cmd:
+      - bash /app/bin/lando/setup-multisite.sh
+
+  add-site:
+    service: appserver
+    description: "Add site to a multisite installation"
+    cmd:
+      - bash /app/bin/lando/add-site.sh

--- a/bin/lando/add-site.sh
+++ b/bin/lando/add-site.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+syntax() {
+  echo "Syntax: lando add-site --slug=<slug> --title=\"<title>\""
+  exit 1
+}
+
+# Parse title and slug arguments
+arguments=`getopt -o '' -l slug:,title: -- "$@"`
+eval set -- "$arguments"
+while true; do
+    case "$1" in
+    --slug) slug=$2; shift 2;;
+    --title) title=$2; shift 2;;
+    --) shift; break;;
+    esac
+done
+[ -z "$slug" ] && echo "ERROR: Missing or empty slug argument" && syntax
+[ -z "$title" ] && echo "ERROR: Missing or empty title argument" && syntax
+
+site_domain=$slug.vip-go-dev.lndo.site
+
+echo "Checking if this is a multisite installation..."
+wp core is-installed --network
+[ $? -ne 0 ] && echo "ERROR: Not a multisite, please run 'lando setup-multisite' first" && exit 1
+
+echo "Checking if $site_domain already belongs to another site..."
+wp --path=$LANDO_WEBROOT site list --field=domain | grep -q "^$site_domain$"
+[ $? -eq 0 ] && echo "ERROR: site with domain $site_domain already exists" && exit 1
+
+echo "Creating the new site..."
+site_id=`wp --path=$LANDO_WEBROOT site create --title="$title" --slug="$slug" --porcelain`
+
+# The multisite installation is in subdirectory mode, so we have to change
+# the siteurl and home options to the proper domain
+echo "Changing 'siteurl' and 'home' options to $site_domain..."
+wp --path=$LANDO_WEBROOT --url="http://vip-go-dev.lndo.site/$slug" option update siteurl "http://$site_domain/"
+wp --path=$LANDO_WEBROOT --url="http://vip-go-dev.lndo.site/$slug" option update home "http://$site_domain/"
+
+# We also need to change the domain in wp_blogs. This cannot be done from wp-cli
+# (only from wp-admin), so we need to run a DB query to change it
+echo "Changing the wp_blogs domain to $site_domain..."
+echo "UPDATE wp_blogs SET domain=\"$site_domain\", path=\"/\" WHERE blog_id=$site_id" |
+mysql -u$DB_USER -p$DB_PASS -h$DB_HOST $DB_NAME
+[ $? -ne 0 ] && echo "ERROR: couldn't change the domain in the wp_blogs table" && exit 1
+
+echo
+echo "======================================================================"
+echo "Site '$title' added correctly"
+echo
+echo "You can access it using these URLs:"
+echo "  http://$site_domain/"
+echo "  http://$site_domain/wp-admin/"
+echo "======================================================================"

--- a/bin/lando/add-site.sh
+++ b/bin/lando/add-site.sh
@@ -29,20 +29,7 @@ wp --path=$LANDO_WEBROOT site list --field=domain | grep -q "^$site_domain$"
 [ $? -eq 0 ] && echo "ERROR: site with domain $site_domain already exists" && exit 1
 
 echo "Creating the new site..."
-site_id=`wp --path=$LANDO_WEBROOT site create --title="$title" --slug="$slug" --porcelain`
-
-# The multisite installation is in subdirectory mode, so we have to change
-# the siteurl and home options to the proper domain
-echo "Changing 'siteurl' and 'home' options to $site_domain..."
-wp --path=$LANDO_WEBROOT --url="http://vip-go-dev.lndo.site/$slug" option update siteurl "http://$site_domain/"
-wp --path=$LANDO_WEBROOT --url="http://vip-go-dev.lndo.site/$slug" option update home "http://$site_domain/"
-
-# We also need to change the domain in wp_blogs. This cannot be done from wp-cli
-# (only from wp-admin), so we need to run a DB query to change it
-echo "Changing the wp_blogs domain to $site_domain..."
-echo "UPDATE wp_blogs SET domain=\"$site_domain\", path=\"/\" WHERE blog_id=$site_id" |
-mysql -u$DB_USER -p$DB_PASS -h$DB_HOST $DB_NAME
-[ $? -ne 0 ] && echo "ERROR: couldn't change the domain in the wp_blogs table" && exit 1
+wp --path=$LANDO_WEBROOT site create --title="$title" --slug="$slug"
 
 echo
 echo "======================================================================"

--- a/bin/lando/setup-multisite.sh
+++ b/bin/lando/setup-multisite.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Check if this is already a multisite installation
+wp core is-installed --network
+[ $? -eq 0 ] && echo "WARNING: Multisite already setup, no need to do anything" && exit 1
+
+echo "Converting installation to multisite..."
+wp core multisite-convert --path=$LANDO_WEBROOT --title="VIP Go Dev Network"
+
+echo "=============================================================="
+echo "WordPress installation converted to multisite"
+echo
+echo "You can now add sites with \"lando add-site <slug> <title>\""
+echo
+echo "If you add a site manually from wp-admin, please use this as"
+echo "the site url: http://<slug>.vip-go-dev.lndo.site"
+echo "=============================================================="

--- a/bin/lando/setup-multisite.sh
+++ b/bin/lando/setup-multisite.sh
@@ -5,13 +5,14 @@ wp core is-installed --network
 [ $? -eq 0 ] && echo "WARNING: Multisite already setup, no need to do anything" && exit 1
 
 echo "Converting installation to multisite..."
-wp core multisite-convert --path=$LANDO_WEBROOT --title="VIP Go Dev Network"
+wp core multisite-convert --path=$LANDO_WEBROOT --title="VIP Go Dev Network" --subdomains
 
-echo "=============================================================="
+echo "=========================================================================="
 echo "WordPress installation converted to multisite"
 echo
-echo "You can now add sites with \"lando add-site <slug> <title>\""
+echo "You can now add sites with:"
+echo "  lando add-site --slug=<slug> --title=\"<title>\""
 echo
-echo "If you add a site manually from wp-admin, please use this as"
-echo "the site url: http://<slug>.vip-go-dev.lndo.site"
-echo "=============================================================="
+echo "You can also add sites manually from wp-admin. In both cases, sites"
+echo "will follow this url schema: http://<slug>.vip-go-dev.lndo.site/"
+echo "=========================================================================="

--- a/bin/lando/setup.sh
+++ b/bin/lando/setup.sh
@@ -55,7 +55,7 @@ echo_heading "Installing WordPress $WP_VERSION"
 wp core install \
 	--path=$LANDO_WEBROOT \
 	--url="http://vip-go-dev.lndo.site" \
-	'--title="VIP Go Dev"' \
+	--title="VIP Go Dev" \
 	--admin_user="vipgo" \
 	--admin_password="password" \
 	--admin_email="vip@localhost.local" \


### PR DESCRIPTION
Add multisite support to the Lando dev environment.

There are two new commands:

1. `lando setup-multisite`
This will install the network and add the required tables for multisite Wordpress

1. `lando add-site --slug=<slug> --title="<title>"`
This adds a subsite that can be accessed on `http://<slug>.vip-go-dev.lndo.site/`.

Note: I'm using subdomain mode for multisite as it suits better for this use case. It know we use subdirectory mode in production (although we end up setting a different domain), but I don't know if this difference can have any consequence on functionality.