### PR TITLE
Add StatsD to Lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -52,6 +52,11 @@ services:
     - appserver
   memcached:
     type: memcached:1.5.12
+  statsd:
+    type: compose
+    services:
+      image: statsd/statsd:v0.8.6
+      command: node stats.js /app/configs/statsd-config.js
 tooling:
   test:
     service: appserver

--- a/bin/lando/setup.sh
+++ b/bin/lando/setup.sh
@@ -46,6 +46,9 @@ wp config create \
 	--dbpass=$DB_PASS \
 	--dbhost=$DB_HOST \
 	--extra-php <<PHP
+define( 'VIP_STATSD_HOST', 'statsd' );
+define( 'VIP_STATSD_PORT', 8125 );
+
 require( __DIR__ . '/config/wp-config-defaults.php' );
 PHP
 

--- a/bin/lando/setup.sh
+++ b/bin/lando/setup.sh
@@ -46,9 +46,6 @@ wp config create \
 	--dbpass=$DB_PASS \
 	--dbhost=$DB_HOST \
 	--extra-php <<PHP
-define( 'VIP_STATSD_HOST', 'statsd' );
-define( 'VIP_STATSD_PORT', 8125 );
-
 require( __DIR__ . '/config/wp-config-defaults.php' );
 PHP
 

--- a/configs/statsd-config.js
+++ b/configs/statsd-config.js
@@ -124,7 +124,7 @@ Optional Variables:
                          changes. The default is true. Set this to false to disable.
 */
 {
-  port: 8125
+  port: 8126
 , backends: [ "./backends/console" ]
 // Set this to true if you want to show all received messages in the console
 , dumpMessages: false

--- a/configs/statsd-config.js
+++ b/configs/statsd-config.js
@@ -1,0 +1,131 @@
+/*
+Graphite Required Variable:
+
+(Leave this unset to avoid sending stats to Graphite.
+ Set debug flag and leave this unset to run in 'dry' debug mode -
+ useful for testing statsd clients without a Graphite server.)
+
+  graphiteHost:     hostname or IP of Graphite server
+
+Optional Variables:
+
+  graphitePort:     port for the graphite text collector [default: 2003]
+  graphitePicklePort: port for the graphite pickle collector [default: 2004]
+  graphiteProtocol: either 'text' or 'pickle' [default: 'text']
+  backends:         an array of backends to load. Each backend must exist
+                    by name in the directory backends/. If not specified,
+                    the default graphite backend will be loaded.
+                    * example for console and graphite:
+                    [ "./backends/console", "./backends/graphite" ]
+
+  servers:          an array of server configurations.
+                    If not specified, the server, address,
+                    address_ipv6, and port top-level configuration
+                    options are used to configure a single server for
+                    backwards-compatibility
+                    Each server configuration supports the following keys:
+    server:         the server to load. The server must exist by name in the directory
+                    servers/. If not specified, the default udp server will be loaded.
+                    * example for tcp server:
+                    "./servers/tcp"
+    address:        address to listen on [default: 0.0.0.0]
+    address_ipv6:   defines if the address is an IPv4 or IPv6 address [true or false, default: false]
+    port:           port to listen for messages on [default: 8125]
+    socket:         (only for tcp servers) path to unix domain socket which will be used to receive
+                    metrics [default: undefinded]
+    socket_mod:     (only for tcp servers) file mode which should be applied to unix domain socket, relevant
+                    only if socket option is used [default: undefined]
+
+  debug:            debug flag [default: false]
+  mgmt_address:     address to run the management TCP interface on
+                    [default: 0.0.0.0]
+  mgmt_port:        port to run the management TCP interface on [default: 8126]
+  title:            Allows for overriding the process title. [default: statsd]
+                    if set to false, will not override the process title and let the OS set it.
+                    The length of the title has to be less than or equal to the binary name + cli arguments
+                    NOTE: This does not work on Mac's with node versions prior to v0.10
+
+  healthStatus:     default health status to be returned and statsd process starts ['up' or 'down', default: 'up']
+  dumpMessages:     log all incoming messages
+  flushInterval:    interval (in ms) to flush metrics to each backend
+  percentThreshold: for time information, calculate the Nth percentile(s)
+                    (can be a single value or list of floating-point values)
+                    negative values mean to use "top" Nth percentile(s) values
+                    [%, default: 90]
+  flush_counts:     send stats_counts metrics [default: true]
+
+  keyFlush:         log the most frequently sent keys [object, default: undefined]
+    interval:       how often to log frequent keys [ms, default: 0]
+    percent:        percentage of frequent keys to log [%, default: 100]
+    log:            location of log file for frequent keys [default: STDOUT]
+  deleteIdleStats:  don't send values to graphite for inactive counters, sets, gauges, or timers
+                    as opposed to sending 0.  For gauges, this unsets the gauge (instead of sending
+                    the previous value). Can be individually overridden. [default: false]
+  deleteGauges:     don't send values to graphite for inactive gauges, as opposed to sending the previous value [default: false]
+  gaugesMaxTTL:     number of flush cycles to wait before the gauge is marked as inactive, to use in combination with deleteGauges [default: 1]
+  deleteTimers:     don't send values to graphite for inactive timers, as opposed to sending 0 [default: false]
+  deleteSets:       don't send values to graphite for inactive sets, as opposed to sending 0 [default: false]
+  deleteCounters:   don't send values to graphite for inactive counters, as opposed to sending 0 [default: false]
+  prefixStats:      prefix to use for the statsd statistics data for this running instance of statsd [default: statsd]
+                    applies to both legacy and new namespacing
+  keyNameSanitize:  sanitize all stat names on ingress [default: true]
+                    If disabled, it is up to the backends to sanitize keynames
+                    as appropriate per their storage requirements.
+
+  calculatedTimerMetrics: List of timer metrics that will be sent. Default will send all metrics.
+                          To filter on percents and top percents: append '_percent' to the metric name.
+                          Example: calculatedTimerMetrics: ['count', 'median', 'upper_percent', 'histogram']
+
+  console:
+    prettyprint:    whether to prettyprint the console backend
+                    output [true or false, default: true]
+
+  log:              log settings [object, default: undefined]
+    backend:        where to log: stdout or syslog [string, default: stdout]
+    application:    name of the application for syslog [string, default: statsd]
+    level:          log level for [node-]syslog [string, default: LOG_INFO]
+
+  graphite:
+    legacyNamespace:  use the legacy namespace [default: true]
+    globalPrefix:     global prefix to use for sending stats to graphite [default: "stats"]
+    prefixCounter:    graphite prefix for counter metrics [default: "counters"]
+    prefixTimer:      graphite prefix for timer metrics [default: "timers"]
+    prefixGauge:      graphite prefix for gauge metrics [default: "gauges"]
+    prefixSet:        graphite prefix for set metrics [default: "sets"]
+    globalSuffix:     global suffix to use for sending stats to graphite [default: ""]
+                      This is particularly useful for sending per host stats by
+                      settings this value to: require('os').hostname().split('.')[0]
+
+  repeater:         an array of hashes of the for host: and port:
+                    that details other statsd servers to which the received
+                    packets should be "repeated" (duplicated to).
+                    e.g. [ { host: '10.10.10.10', port: 8125 },
+                           { host: 'observer', port: 88125 } ]
+
+  repeaterProtocol: whether to use udp4, udp6, or tcp for repeaters.
+                    ["udp4," "udp6", or "tcp" default: "udp4"]
+
+  histogram:        for timers, an array of mappings of strings (to match metrics) and
+                    corresponding ordered non-inclusive upper limits of bins.
+                    For all matching metrics, histograms are maintained over
+                    time by writing the frequencies for all bins.
+                    'inf' means infinity. A lower limit of 0 is assumed.
+                    default: [], meaning no histograms for any timer.
+                    First match wins.  examples:
+                    * histogram to only track render durations, with unequal
+                      class intervals and catchall for outliers:
+                      [ { metric: 'render', bins: [ 0.01, 0.1, 1, 10, 'inf'] } ]
+                    * histogram for all timers except 'foo' related,
+                      equal class interval and catchall for outliers:
+                     [ { metric: 'foo', bins: [] },
+                       { metric: '', bins: [ 50, 100, 150, 200, 'inf'] } ]
+
+  automaticConfigReload: whether to watch the config file and reload it when it
+                         changes. The default is true. Set this to false to disable.
+*/
+{
+  port: 8125
+, backends: [ "./backends/console" ]
+// Set this to true if you want to show all received messages in the console
+, dumpMessages: false
+}

--- a/configs/wp-config-defaults.php
+++ b/configs/wp-config-defaults.php
@@ -84,6 +84,16 @@ if ( ! defined( 'VIP_ELASTICSEARCH_PASSWORD' ) ) {
 }
 
 /**
+ * StatsD
+ */
+if ( ! defined( 'VIP_STATSD_HOST' ) ) {
+	define( 'VIP_STATSD_HOST', 'statsd' );
+}
+if ( ! defined( 'VIP_STATSD_PORT' ) ) {
+	define( 'VIP_STATSD_PORT', 8126 );
+}
+
+/**
  * Debugging
  */
 if ( ! defined( 'WP_DEBUG' ) ) {


### PR DESCRIPTION
* Added as a compose (aka custom) service, as Lando doesn't support StatsD
* It's configured to use the console as the backend, so it will dump a summary of all received metrics every 10 seconds
* You can configure it to dump every received message by setting dumpMessages to true in the config (restart needed)
* The 'VIP_STATSD_HOST' and 'VIP_STATSD_PORT' defines are properly configured, so metrics are sent to StatsD out of the box