### PR TITLE
Forward host ports to the db and es services

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -42,6 +42,7 @@ services:
     type: elasticsearch:custom
     overrides:
       image: bitnami/elasticsearch:7.8.0
+    portforward: 13306
   phpmyadmin:
     type: phpmyadmin
     hosts:
@@ -52,6 +53,8 @@ services:
     - appserver
   memcached:
     type: memcached:1.5.12
+  database:
+    portforward: 13306
 tooling:
   test:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -42,7 +42,7 @@ services:
     type: elasticsearch:custom
     overrides:
       image: bitnami/elasticsearch:7.8.0
-    portforward: 13306
+    portforward: 19200
   phpmyadmin:
     type: phpmyadmin
     hosts:


### PR DESCRIPTION
To access ES directly from the host, and to have a static MariaDB host port, add the `portforward` configs to `.lando.yml`.

## Test Steps

1. `lando rebuild --yes`
1. `lando info` - should show both the `vip-search` and `database` services as having `19200` and `13306` exposed in their `external_connection` info.