### PR TITLE
Use ABSPATH instead of DIR for loading vip-config

### DIFF
--- a/configs/wp-config-defaults.php
+++ b/configs/wp-config-defaults.php
@@ -54,8 +54,8 @@ if ( ! defined( 'FILES_CLIENT_SITE_ID' ) ) {
 /**
  * VIP Config
  */
-if ( file_exists( __DIR__ . '/wp-content/vip-config/vip-config.php' ) ) {
-	require_once( __DIR__ . '/wp-content/vip-config/vip-config.php' );
+if ( file_exists( ABSPATH . '/wp-content/vip-config/vip-config.php' ) ) {
+	require_once( ABSPATH . '/wp-content/vip-config/vip-config.php' );
 }
 
 /**


### PR DESCRIPTION
ABSPATH properly resolves to where the wp installation is located and is actually how we want to traverse to other files.

- `__DIR__` => `/app/configs`
- `ABSPATH` => `/app/wp` (correct)

Without this change, vip-config isn't loaded at all 🙀 